### PR TITLE
Add pg_int_to_bit_agg aggregate for aggregating integers to a bitstring.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 EXTENSION = pg_bitcount       # the extensions name
-DATA = pg_bitcount--0.0.1.sql  # script files to install
+DATA = pg_bitcount--0.0.2.sql  # script files to install
 REGRESS = bitcount_test
 
 # postgres build stuff
 MODULE_big = pg_bitcount
-OBJS = src/pg_bitcount.o src/bitcount.o
+OBJS = src/pg_bitcount.o src/bitcount.o src/int_to_bit_agg.o
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pg_bitcount
 [![Build Status](https://travis-ci.org/thehyve/pg_bitcount.svg?branch=master)](https://travis-ci.org/thehyve/pg_bitcount/branches)
 
-PostgreSQL extension providing a bitcount function.
+PostgreSQL extension providing a bitcount function and an aggregate function that aggregates integers in a bit string.
 
 
 ## Build
@@ -30,9 +30,9 @@ make performance_tester && ./performance_tester
 ### Run database tests
 ```bash
 # Create database role for testing
-sudo -u postgres psql -c "create role ${USER} with login superuser" 
+sudo -u postgres psql -p 5433 -c "create role ${USER} with login superuser" 
 # Execute checks
-make installcheck
+PGPORT=5433 make installcheck
 ```
 
 
@@ -48,14 +48,24 @@ make clean && make && sudo make install
 ## Usage
 
 ```sql
-# Register the extension in PostgreSQL
+-- Register the extension in PostgreSQL
 create extension pg_bitcount;
 
-# Use the pg_bitcount function
+-- Use the pg_bitcount function
 select public.pg_bitcount(127::bit(8)); -- 7
 select public.pg_bitcount(B'101010101'); -- 5 
 select public.pg_bitcount((17^15)::bigint::bit(128) << 64 | (17^14)::bigint::bit(128)); -- 58
+
+-- Use the pg_int_to_bit_agg aggregate using a bit string of size 24
+select public.pg_bitcount(public.pg_int_to_bit_agg(i::int, 24)) from (select generate_series(2, 8) as i) data; -- 7
 ```
+
+## List of functions
+
+ Schema |    Name           | Result data type | Argument data types |  Type  
+--------|-------------------|------------------|---------------------|--------
+ public | pg_bitcount       | integer          | bit                 | normal
+ public | pg_int_to_bit_agg | bit              | integer, integer    | agg
 
 
 ## Acknowledgements

--- a/expected/bitcount_test.out
+++ b/expected/bitcount_test.out
@@ -1,4 +1,11 @@
 create extension pg_bitcount;
+\df pg_bitcount
+                           List of functions
+ Schema |    Name     | Result data type | Argument data types |  Type  
+--------+-------------+------------------+---------------------+--------
+ public | pg_bitcount | integer          | bit                 | normal
+(1 row)
+
 -- Check some small numbers
 select pg_bitcount(B'0');
  pg_bitcount 
@@ -37,4 +44,74 @@ from (select (17^15)::bigint::bit(128) << 64 | (17^14)::bigint::bit(128) as bits
 ------------------------------------------------------------------------------------------------------------------------------------+----------+--------------------+-------
  (00100111101110010101111010011001011111100010000111011010000000000000001001010110001100101011110110111100001000000001101111100000) |       58 |                 58 | t
 (1 row)
+
+\df pg_int_to_bit_agg
+                             List of functions
+ Schema |       Name        | Result data type | Argument data types | Type 
+--------+-------------------+------------------+---------------------+------
+ public | pg_int_to_bit_agg | bit              | integer, integer    | agg
+(1 row)
+
+-- Aggregate numbers to a bit string
+select pg_int_to_bit_agg(i::int, 24)::text as bits
+from (select generate_series(2, 8) as i) data;
+           bits           
+--------------------------
+ 001111111000000000000000
+(1 row)
+
+select pg_int_to_bit_agg(i::int, 24)::text as bits
+from (select generate_series(0, 3) as i) data;
+           bits           
+--------------------------
+ 111100000000000000000000
+(1 row)
+
+-- Aggregating over an empty set requires coalescing 
+select coalesce(pg_int_to_bit_agg(i::int, 10), 0::bit(10))::text as bits
+from (select 0 as i) data where i > 0;
+    bits    
+------------
+ 0000000000
+(1 row)
+
+-- Count bits of aggregate numbers
+select pg_bitcount(pg_int_to_bit_agg(i::int, 24))
+from (select generate_series(2, 8) as i) data;
+ pg_bitcount 
+-------------
+           7
+(1 row)
+
+-- Error on exceeding bit length 
+select pg_int_to_bit_agg(i::int, 24)::text
+from (select generate_series(20, 32) as i) data;
+ERROR:  bit index 24 out of valid range (0..24)
+select pg_int_to_bit_agg(i::int, 24)::text
+from (select generate_series(-5, 5) as i) data;
+ERROR:  bit index -5 out of valid range (0..24)
+-- Check aggregate with get_bit. Expect bits 3 and 4 to be set.
+select i, get_bit(pg_int_to_bit_agg(j::int, 16), i) as result
+from (select generate_series(3, 4) as j) selection,
+(select generate_series(0, 15) as i) data
+group by i order by i;
+ i  | result 
+----+--------
+  0 |      0
+  1 |      0
+  2 |      0
+  3 |      1
+  4 |      1
+  5 |      0
+  6 |      0
+  7 |      0
+  8 |      0
+  9 |      0
+ 10 |      0
+ 11 |      0
+ 12 |      0
+ 13 |      0
+ 14 |      0
+ 15 |      0
+(16 rows)
 

--- a/pg_bitcount--0.0.1.sql
+++ b/pg_bitcount--0.0.1.sql
@@ -1,7 +1,0 @@
--- complain if script is sourced in psql, rather than via CREATE EXTENSION
-\echo Use "create extension pg_bitcount" to load this file. \quit
-create function public.pg_bitcount(bit)
-returns integer
-as '$libdir/pg_bitcount'
-language C immutable strict;
-

--- a/pg_bitcount--0.0.2.sql
+++ b/pg_bitcount--0.0.2.sql
@@ -1,0 +1,16 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "create extension pg_bitcount" to load this file. \quit
+create function public.pg_bitcount(bit)
+returns integer
+as '$libdir/pg_bitcount', 'pg_bitcount'
+language C immutable strict;
+
+create function public.pg_int_to_bit_agg_transfn(bit, int, int)
+returns bit
+as '$libdir/pg_bitcount', 'pg_int_to_bit_agg_transfn'
+language C;
+
+create aggregate public.pg_int_to_bit_agg(int, int) (
+    sfunc = pg_int_to_bit_agg_transfn,
+    stype = bit
+);

--- a/pg_bitcount.control
+++ b/pg_bitcount.control
@@ -1,5 +1,5 @@
 # pg_bitcount extension
 comment = 'pg_bitcount function'
-default_version = '0.0.1'
+default_version = '0.0.2'
 relocatable = true
 

--- a/src/int_to_bit_agg.c
+++ b/src/int_to_bit_agg.c
@@ -1,0 +1,59 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+
+#include "int_to_bit_agg.h"
+
+// Based on the bitsetbit function in varbit.c:
+// https://github.com/postgres/postgres/blob/REL_10_0/src/backend/utils/adt/varbit.c#L1839
+void
+setBitAtPosition(VarBit *bits, int32 position) {
+    bits8 *r;
+    int byteNo;
+    int bitNo;
+
+    Assert(bits != NULL);
+
+    // Check if the position is within the length of the bitstring.
+    if (position < 0 || position >= VARBITLEN(bits)) {
+        ereport(ERROR,
+                (errcode(ERRCODE_ARRAY_SUBSCRIPT_ERROR), errmsg(
+                        "bit index %d out of valid range (0..%d)", position,
+                        VARBITLEN(bits))));
+    }
+
+    // Set bit at position
+    r = VARBITS(bits);
+    byteNo = position / BITS_PER_BYTE;
+    bitNo = BITS_PER_BYTE - 1 - (position % BITS_PER_BYTE);
+    r[byteNo] |= (1 << bitNo);
+}
+
+// The structure of this function is based on the makeStringAggState function in varlena.c:
+// https://github.com/postgres/postgres/blob/REL_10_0/src/backend/utils/adt/varlena.c#L4664
+VarBit*
+makeIntToBitAggState(FunctionCallInfo fcinfo, int32 bitlen) {
+    VarBit* state;
+    int rlen;
+    MemoryContext aggcontext;
+    MemoryContext oldcontext;
+
+    if (!AggCheckCallContext(fcinfo, &aggcontext)) {
+        /* cannot be called directly because of internal-type argument */
+        elog(ERROR, "int_to_bit_agg_transfn called in non-aggregate context");
+    }
+
+    /*
+     * Create state in aggregate context.  It'll stay there across subsequent
+     * calls.
+     */
+    oldcontext = MemoryContextSwitchTo(aggcontext);
+
+    // Initialise an empty bitstring if none is provided.
+    rlen = VARBITTOTALLEN(bitlen);
+    state = (VarBit*) palloc0(rlen);
+    SET_VARSIZE(state, rlen);
+    VARBITLEN (state) = bitlen;
+
+    MemoryContextSwitchTo(oldcontext);
+
+    return state;
+}

--- a/src/int_to_bit_agg.h
+++ b/src/int_to_bit_agg.h
@@ -1,0 +1,31 @@
+// -*- tab-width:4 ; indent-tabs-mode:nil -*-
+
+#ifndef INT_TO_BIT_AGG_H
+#define INT_TO_BIT_AGG_H
+
+//#include <c.h>
+#include <postgres.h>
+#include <fmgr.h>
+#include <utils/builtins.h>
+#include <utils/varbit.h>
+
+/*
+ * setBitAtPosition
+ *
+ * Given an instance of type 'bit', sets the bit at position 'position'.
+ * The purpose of this function is to be used in the pg_int_to_bit_agg aggregate.
+ *
+ * The bit location is specified left-to-right in a zero-based fashion
+ * consistent with the get_bit and set_bit functions.
+ */
+void setBitAtPosition(VarBit *bits, int32 position);
+
+/*
+ * makeIntToBitAggState
+ *
+ * Initialises a state of type 'bit' of length 'bitlen' for the
+ * pg_int_to_bit_agg aggregate.
+ */
+VarBit* makeIntToBitAggState(FunctionCallInfo fcinfo, int32 bitlen);
+
+#endif // INT_TO_BIT_AGG_H

--- a/src/pg_bitcount.c
+++ b/src/pg_bitcount.c
@@ -4,10 +4,16 @@
 #include <fmgr.h>
 #include <utils/builtins.h>
 #include <utils/varbit.h>
+#include "int_to_bit_agg.h"
 #include "bitcount.h"
 
 PG_MODULE_MAGIC;
 
+/*
+ * pg_bitcount - Counts the number of bits set in a bit string.
+ *
+ * Syntax: pg_bitcount(arg bit) RETURNS int
+ */
 PG_FUNCTION_INFO_V1(pg_bitcount);
 Datum
 pg_bitcount(PG_FUNCTION_ARGS)
@@ -17,4 +23,31 @@ pg_bitcount(PG_FUNCTION_ARGS)
     bits8 *end = VARBITEND(arg);
     int32 count = bitcount(begin, end);
     PG_RETURN_INT32(count);
+}
+
+/*
+ * pg_int_to_bit_agg - Aggregates integers in a bit string.
+ * For each aggregate integer, the bit at that position is set.
+ * The second parameter specifies the length of the bit string.
+ *
+ * Syntax: pg_int_to_bit_agg(value int, length int) RETURNS bit
+ */
+PG_FUNCTION_INFO_V1(pg_int_to_bit_agg_transfn);
+Datum
+pg_int_to_bit_agg_transfn(PG_FUNCTION_ARGS)
+{
+    VarBit *state;
+    int32 value;
+
+    if (PG_ARGISNULL(0)) {
+        state = makeIntToBitAggState(fcinfo, PG_GETARG_INT32(2));
+    } else {
+        state = PG_GETARG_VARBIT_P(0);
+    }
+
+    value = PG_GETARG_INT32(1);
+
+    setBitAtPosition(state, value);
+
+    PG_RETURN_VARBIT_P(state);
 }


### PR DESCRIPTION
Documentation stiil needs to be updated.

Performance improvement can be verified with the following queries:

Without the custom aggregate (~7s):
```sql
select pg_bitcount(bit_or(1::bit(1000000) << i::integer)) as count
from (select generate_series(1, 20000) as i) data;
```

With the new `pg_int_to_bit_agg` aggregate (~7ms):
```sql
select pg_bitcount(pg_int_to_bit_agg(i::integer, 1000000)) as count
from (select generate_series(1, 20000) as i) data;
```